### PR TITLE
Fix email sending logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,16 +3,4 @@ __pycache__/**
 Monito.db
 *.machines
 .idea/**
-#!/bin/sh
- 
-(
-echo "To: " $1
-echo "From: Monito <no-reply@ericsson.com>"
-echo "Subject: Unauthorized access to $2"
-echo "Content-Type: text/html"
-echo
-echo "The following users recently access your machine ($2)."
-echo
-echo "$3"
-echo
-) | /usr/sbin/sendmail -t
+.env

--- a/send_mail.sh
+++ b/send_mail.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+. ./.env
+USE_GMAIL=${USE_GMAIL:-false}
 function send_email()
 {
-  cat "$1" | sed -e s/'${owner}'/"$2"/g -e s/'${active_users}'/"$4"/g -e s/'${machine}'/"$3"/g -e s/'${recipients}'/"$5"/g | /usr/sbin/sendmail -t
+  if [[ ${USE_GMAIL} == "true" ]]; then
+      echo "Using gmail smtp server"
+      cat "$1" | sed -e s/'${owner}'/"$2"/g -e s/'${active_users}'/"$4"/g -e s/'${machine}'/"$3"/g | curl -s --url 'smtps://smtp.gmail.com:465' --ssl-reqd  --mail-rcpt "$5" --upload-file - --user "$(echo ${GMAIL_CREDS} | base64 -d)" --insecure
+  else
+      cat "$1" | sed -e s/'${owner}'/"$2"/g -e s/'${active_users}'/"$4"/g -e s/'${machine}'/"$3"/g -e s/'${recipients}'/"$5"/g | /usr/sbin/sendmail -t
+  fi
 }
 
 template_file="$1"


### PR DESCRIPTION
With this, now there is a way to use gmail smtp server for mail sending till the time /usr/bin/sendmail is not fixed.

The user must create a .env file with the following content

```bash
USE_GMAIL=true
GMAIL_CREDS=$(echo foo.bar@gmail.com:password | base64)
```

> Also make sure to turn on the insecure apps mode on in your gmail account from [here](https://myaccount.google.com/lesssecureapps) 