### PR TITLE
Fix errors in the email templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -212,7 +212,7 @@ def send_mail_if_unauthorized_access(machine, owner_vdaIP):
 def format_recipients(mail_recipients):
     txt = "to: {email}"
     recipient_header = []
-    if len(mail_recipients) > 0 and ',' in mail_recipients:
+    if len(mail_recipients) > 0:
         for mail in mail_recipients.split(","):
             recipient_header.append(txt.format(email=mail))
             # prepend a \ so as to provide multiline args for bash inputs.

--- a/email_templates/machine_status_change_mail.txt
+++ b/email_templates/machine_status_change_mail.txt
@@ -1,5 +1,5 @@
 from: "admin@Monito"
-"${recipients}"
+${recipients}
 Subject: Please don't use the machine ${machine}
 Content-Type: text/html
 Hi,

--- a/email_templates/unauthorized_access_mail.txt
+++ b/email_templates/unauthorized_access_mail.txt
@@ -1,5 +1,5 @@
 from: "admin@Monito"
-"${recipients}"
+${recipients}
 Subject: Someone just logged into your machine ${machine}
 Content-Type: text/html
 Hi ${owner},

--- a/send_mail.sh
+++ b/send_mail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-. ./.env
+if [[ -e ./.env ]];then
+  . ./.env
+fi
+
 USE_GMAIL=${USE_GMAIL:-false}
 function send_email()
 {


### PR DESCRIPTION
The templates were enclosing the recipients in a double quote which won't work with sendmail so corrected that.